### PR TITLE
concurrent mget bug for non existing keys

### DIFF
--- a/src/erldis_client.erl
+++ b/src/erldis_client.erl
@@ -430,21 +430,17 @@ parse_state(State, Socket, Data) ->
 			State#redis{remaining=Remaining, pstate=read};
 		{N, {read, nil}} ->
 			% reply with nil
-                        case State#redis.pstate of
-                          empty -> send_reply(State#redis{buffer=[nil]});
-                           read -> NewBuffer = [nil | State#redis.buffer],
-                                   NewState =
-                                   State#redis{remaining=N,
-                                               buffer=NewBuffer,
-                                               pstate=read},
-                                   case N of
-                                     0 -> send_reply(NewState);
-                                     _ -> NewState
-                                   end
-                        end;
-                {_, {read, 0}} when State#redis.pstate =:= empty ->
-                        % this is needed to handle single-line reply empty responses
-                        send_reply(State#redis{buffer=[]});
+			case State#redis.pstate of
+				empty -> send_reply(State#redis{buffer=[nil]});
+				read -> NewBuffer = [nil | State#redis.buffer],
+					case N of
+						0 -> send_reply(State#redis{buffer = NewBuffer});
+						_ -> State#redis{remaining=N, buffer=NewBuffer, pstate=read}
+					end
+			end;
+		{_, {read, 0}} when State#redis.pstate =:= empty ->
+			% this is needed to handle single-line reply empty responses
+			send_reply(State#redis{buffer=[]});
 		{0, {read, NBytes}} ->
 			% reply with Value added to buffer
 			Value = recv_value(Socket, NBytes),


### PR DESCRIPTION
When you are calling mget with many spawned process some of them may not respond due a bug on erldis_client:parse_state/3. This patch resolve the problem.

If you want to reproduce the error try this:

```
-module(mytest).
-author('gustavo.chain@inakanetworks.com').
-vsn('').

-export([init/0]).
-export([mget/1, mget/3, cc_mget/2]).

-define(LINK, erldis_pool_sup:get_random_pid({"10.211.55.3",6379})).

init() ->
    {ok, Pid} = erldis_pool_sup:start_link([{{"10.211.55.3", 6379}, 1}]),
    Pid.

mget(List) ->
    R = erldis:mget(?LINK, List),
    io:format("~p: ~p\n", [self(), R]),
    R.
mget(List, Pid, N) ->
    try
%       io:format("Calling mget~n"),
        mget(List),
%       io:format("Called mget~n"),
        Pid ! {ok, N}
    catch _:X ->
        {error, X, erlang:get_stacktrace()}
    end.

%cc_mget(List) ->
%   lists:foreach(fun(X) -> spawn(?MODULE, mget, [List, X]) end, lists:seq(1, N)).


cc_mget(0, _) ->
    cc_mget_receive(0);
cc_mget(N, Keys) ->
    spawn(?MODULE, mget, [Keys, self(), N]),
    cc_mget(N - 1, Keys).

cc_mget_receive(N) ->
    receive
        {ok, _} ->
            cc_mget_receive(N + 1)
    after 3000 ->
            io:format("Finish with ~p!~n", [N])
    end.
```
